### PR TITLE
Fix activities loader and news article path

### DIFF
--- a/pages/activities/index.js
+++ b/pages/activities/index.js
@@ -40,6 +40,7 @@ const Activities = (props) => {
 
   const { loading, loadData } = useContentLoader(
     'activities',
+    'crypto-activities',
     LOAD_MORE_STEP,
     (count) => dispatch(setLoadedCount(count)),
     (entities) => dispatch(addActivities(entities)),

--- a/pages/news/[slug].js
+++ b/pages/news/[slug].js
@@ -30,7 +30,7 @@ const CurrentPost = (props) => {
     <Layout>
       <Breadcrumbs paths={paths}></Breadcrumbs>
       <Section noTopPadding={true}>
-        <Article post={post} directory={'activities'}></Article>
+        <Article post={post} directory={'news'}></Article>
       </Section>
       <Section>
         <Title color={'purple'}>Может быть интересно</Title>


### PR DESCRIPTION
## Summary
- correct the API path when loading more activities
- fix article directory link in news post page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f80cd7e7c832bb22e71412f393a5a